### PR TITLE
the default cost factor for bcrypt should be 10 (like in current implementations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ for examples of how to add and configure additional authentication strategies.
      * Specifiy number of salt rounds to perform on password. Values >10 are
      * slow.
      */
-    rounds: 8
+    rounds: 10
   }
 ```
 

--- a/config/simpleauth.js
+++ b/config/simpleauth.js
@@ -1,6 +1,6 @@
 module.exports.simpleauth = {
   bcrypt: {
-    rounds: 8
+    rounds: 10
   }
 
 };


### PR DESCRIPTION
At least the used library bryptjs defaults to 10 rounds which is currently also the default in other libraries for other programming languages.

See [this code](https://github.com/dcodeIO/bcrypt.js/blob/0646370dd7cc0277c720786cfd79a4577d7b2f57/src/bcrypt/impl.js#L13)

https://github.com/sg-medien/sails-hook-simple-auth/blob/fd33c23e276da9ad742d3d1cdf738f0ad4e01a8b/config/simpleauth.js#L3

https://github.com/sg-medien/sails-hook-simple-auth/blob/ea49c812296a4fcc05e9a85adf277c04a2e4d90b/README.md
